### PR TITLE
fix: widen research theme body to match card grid width

### DIFF
--- a/layouts/research/list.html
+++ b/layouts/research/list.html
@@ -6,7 +6,7 @@
   </header>
 
   <section class="mt-1 mb-8 prose flex max-w-full flex-col dark:prose-invert">
-    <div class="min-w-0 min-h-0 max-w-prose w-full">{{ .Content }}</div>
+    <div class="min-w-0 min-h-0 max-w-full w-full">{{ .Content }}</div>
   </section>
 
   {{ if gt (len .Pages) 0 }}

--- a/layouts/research/single.html
+++ b/layouts/research/single.html
@@ -5,7 +5,7 @@
     {{ with .Params.summary }}<p class="text-lg text-neutral-500 dark:text-neutral-400">{{ . }}</p>{{ end }}
   </header>
 
-  <article class="prose dark:prose-invert max-w-none mt-6">
+  <article class="prose dark:prose-invert max-w-full mt-6">
     {{ .Content }}
   </article>
 


### PR DESCRIPTION
## Summary

Research テーマページの本文幅がカードと比べて狭い問題（#2）を修正。

`single.html` / `list.html` は prose の 65ch 制約を外すために `max-w-none` ユーティリティを使っていたが、Blowfish はビルド済み CSS バンドルをコミットしており、カスタムレイアウト由来の `max-w-none` は Tailwind のスキャン対象外で**バンドルに生成されていなかった**。そのため本文は 65ch のままで、関連カードのグリッド（コンテナ全幅）より狭く見えていた。

バンドルに実在し `.prose` より後に定義される `max-w-full`（`max-width:100%`）へ変更し、prose の max-width を上書きして本文をカードグリッドと同幅に揃えた。

## Changes

- `layouts/research/single.html`: article `max-w-none` → `max-w-full`（詳細ページ本文）
- `layouts/research/list.html`: 導入文 div `max-w-prose` → `max-w-full`（一覧ページ）

## Test plan

- [x] `hugo server` で EN/JA の `/research/<theme>/` 詳細ページ本文がカードグリッドと同幅で描画されることを確認
- [x] `/research/` 一覧ページの導入文がカードと同幅になることを確認
- [x] 実画面確認（ライト/ダーク両テーマ）

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)