### PR TITLE
refactor: drop redundant project_names from publications

### DIFF
--- a/content/publications/a-practical-guide-of-off-policy-evaluation-for-bandit-p-2010/index.ja.md
+++ b/content/publications/a-practical-guide-of-off-policy-evaluation-for-bandit-p-2010/index.ja.md
@@ -9,7 +9,6 @@ status: "Preprint"
 type: "Preprint"
 paper_lang: "en"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Bandits","Online Learning","Bayesian Optimization"]
 showDate: false
 showReadingTime: false

--- a/content/publications/a-practical-guide-of-off-policy-evaluation-for-bandit-p-2010/index.md
+++ b/content/publications/a-practical-guide-of-off-policy-evaluation-for-bandit-p-2010/index.md
@@ -9,7 +9,6 @@ status: "Preprint"
 type: "Preprint"
 paper_lang: "en"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Bandits","Online Learning","Bayesian Optimization"]
 showDate: false
 showReadingTime: false

--- a/content/publications/a-simple-heuristic-for-bayesian-optimization-with-a-low/index.ja.md
+++ b/content/publications/a-simple-heuristic-for-bayesian-optimization-with-a-low/index.ja.md
@@ -8,7 +8,6 @@ status: "Preprint"
 type: "Preprint"
 paper_lang: "en"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Bandits","Online Learning","Bayesian Optimization"]
 showDate: false
 showReadingTime: false

--- a/content/publications/a-simple-heuristic-for-bayesian-optimization-with-a-low/index.md
+++ b/content/publications/a-simple-heuristic-for-bayesian-optimization-with-a-low/index.md
@@ -8,7 +8,6 @@ status: "Preprint"
 type: "Preprint"
 paper_lang: "en"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Bandits","Online Learning","Bayesian Optimization"]
 showDate: false
 showReadingTime: false

--- a/content/publications/a-slingshot-approach-to-learning-in-monotone-games-2023/index.ja.md
+++ b/content/publications/a-slingshot-approach-to-learning-in-monotone-games-2023/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/actor-critic-2021-2/index.ja.md
+++ b/content/publications/actor-critic-2021-2/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/actor-critic-2021/index.ja.md
+++ b/content/publications/actor-critic-2021/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/adaptively-perturbed-mirror-descent-for-learning-in-gam-2024/index.ja.md
+++ b/content/publications/adaptively-perturbed-mirror-descent-for-learning-in-gam-2024/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/adaptively-perturbed-mirror-descent-for-learning-in-gam-2024/index.md
+++ b/content/publications/adaptively-perturbed-mirror-descent-for-learning-in-gam-2024/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/anytime-capacity-expansion-in-medical-residency-match-b-2022/index.ja.md
+++ b/content/publications/anytime-capacity-expansion-in-medical-residency-match-b-2022/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["fairness-recsys-allocation"]
-project_names: ["Fairness in Recommender Systems and Allocation"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/anytime-capacity-expansion-in-medical-residency-match-b-2022/index.md
+++ b/content/publications/anytime-capacity-expansion-in-medical-residency-match-b-2022/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["fairness-recsys-allocation"]
-project_names: ["Fairness in Recommender Systems and Allocation"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/approximate-state-abstraction-for-markov-games-2025/index.ja.md
+++ b/content/publications/approximate-state-abstraction-for-markov-games-2025/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/approximate-state-abstraction-for-markov-games-2025/index.md
+++ b/content/publications/approximate-state-abstraction-for-markov-games-2025/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/asymmetric-perturbation-in-solving-bilinear-saddle-poin-2025/index.ja.md
+++ b/content/publications/asymmetric-perturbation-in-solving-bilinear-saddle-poin-2025/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/asymmetric-perturbation-in-solving-bilinear-saddle-poin-2026/index.ja.md
+++ b/content/publications/asymmetric-perturbation-in-solving-bilinear-saddle-poin-2026/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/asymmetric-perturbation-in-solving-bilinear-saddle-poin-2026/index.md
+++ b/content/publications/asymmetric-perturbation-in-solving-bilinear-saddle-poin-2026/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/bandits-online-learning-2018/index.ja.md
+++ b/content/publications/bandits-online-learning-2018/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Bandits","Online Learning","Bayesian Optimization"]
 showDate: false
 showReadingTime: false

--- a/content/publications/bandits-online-learning-2025/index.ja.md
+++ b/content/publications/bandits-online-learning-2025/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Bandits","Online Learning","Bayesian Optimization"]
 showDate: false
 showReadingTime: false

--- a/content/publications/black-box-budget-2019/index.ja.md
+++ b/content/publications/black-box-budget-2019/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Bandits","Online Learning","Bayesian Optimization"]
 showDate: false
 showReadingTime: false

--- a/content/publications/boosting-perturbed-gradient-ascent-for-last-iterate-con-2025/index.ja.md
+++ b/content/publications/boosting-perturbed-gradient-ascent-for-last-iterate-con-2025/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/boosting-perturbed-gradient-ascent-for-last-iterate-con-2025/index.md
+++ b/content/publications/boosting-perturbed-gradient-ascent-for-last-iterate-con-2025/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/computing-strategies-of-american-football-via-counterfa-2022/index.ja.md
+++ b/content/publications/computing-strategies-of-american-football-via-counterfa-2022/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Workshop"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/computing-strategies-of-american-football-via-counterfa-2022/index.md
+++ b/content/publications/computing-strategies-of-american-football-via-counterfa-2022/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Workshop"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/decision-transformer-2023/index.ja.md
+++ b/content/publications/decision-transformer-2023/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/direct-expected-quadratic-utility-maximization-for-mean-2021/index.ja.md
+++ b/content/publications/direct-expected-quadratic-utility-maximization-for-mean-2021/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Workshop"
 paper_lang: "en"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/direct-expected-quadratic-utility-maximization-for-mean-2021/index.md
+++ b/content/publications/direct-expected-quadratic-utility-maximization-for-mean-2021/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Workshop"
 paper_lang: "en"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/efficient-creative-selection-in-online-advertising-usin-2025/index.ja.md
+++ b/content/publications/efficient-creative-selection-in-online-advertising-usin-2025/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Bandits","Online Learning","Bayesian Optimization"]
 showDate: false
 showReadingTime: false

--- a/content/publications/efficient-creative-selection-in-online-advertising-usin-2025/index.md
+++ b/content/publications/efficient-creative-selection-in-online-advertising-usin-2025/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Bandits","Online Learning","Bayesian Optimization"]
 showDate: false
 showReadingTime: false

--- a/content/publications/evaluation-of-best-of-n-sampling-strategies-for-languag-2024/index.ja.md
+++ b/content/publications/evaluation-of-best-of-n-sampling-strategies-for-languag-2024/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/evaluation-of-best-of-n-sampling-strategies-for-languag/index.ja.md
+++ b/content/publications/evaluation-of-best-of-n-sampling-strategies-for-languag/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Journal"
 paper_lang: "en"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/evaluation-of-best-of-n-sampling-strategies-for-languag/index.md
+++ b/content/publications/evaluation-of-best-of-n-sampling-strategies-for-languag/index.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Journal"
 paper_lang: "en"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/exploration-of-unranked-items-in-safe-online-learning-t-2023/index.ja.md
+++ b/content/publications/exploration-of-unranked-items-in-safe-online-learning-t-2023/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["fairness-recsys-allocation"]
-project_names: ["Fairness in Recommender Systems and Allocation"]
 topics: ["Fairness","Recommender Systems","Resource Allocation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/exploration-of-unranked-items-in-safe-online-learning-t-2023/index.md
+++ b/content/publications/exploration-of-unranked-items-in-safe-online-learning-t-2023/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Fairness","Recommender Systems","Resource Allocation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/fair-matrix-factorisation-for-large-scale-recommender-s-2022/index.ja.md
+++ b/content/publications/fair-matrix-factorisation-for-large-scale-recommender-s-2022/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Workshop"
 paper_lang: "en"
 projects: ["fairness-recsys-allocation"]
-project_names: ["Fairness in Recommender Systems and Allocation"]
 topics: ["Fairness","Recommender Systems","Resource Allocation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/fair-matrix-factorisation-for-large-scale-recommender-s-2022/index.md
+++ b/content/publications/fair-matrix-factorisation-for-large-scale-recommender-s-2022/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Workshop"
 paper_lang: "en"
 projects: ["fairness-recsys-allocation"]
-project_names: ["Fairness in Recommender Systems and Allocation"]
 topics: ["Fairness","Recommender Systems","Resource Allocation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/fairness-recsys-allocation-2022/index.ja.md
+++ b/content/publications/fairness-recsys-allocation-2022/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["fairness-recsys-allocation"]
-project_names: ["Fairness in Recommender Systems and Allocation"]
 topics: ["Fairness","Recommender Systems","Resource Allocation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/fairness-recsys-allocation-2023-2/index.ja.md
+++ b/content/publications/fairness-recsys-allocation-2023-2/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["fairness-recsys-allocation"]
-project_names: ["Fairness in Recommender Systems and Allocation"]
 topics: ["Fairness","Recommender Systems","Resource Allocation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/fairness-recsys-allocation-2023-3/index.ja.md
+++ b/content/publications/fairness-recsys-allocation-2023-3/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["fairness-recsys-allocation"]
-project_names: ["Fairness in Recommender Systems and Allocation"]
 topics: ["Fairness","Recommender Systems","Resource Allocation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/fairness-recsys-allocation-2023/index.ja.md
+++ b/content/publications/fairness-recsys-allocation-2023/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["fairness-recsys-allocation"]
-project_names: ["Fairness in Recommender Systems and Allocation"]
 topics: ["Fairness","Recommender Systems","Resource Allocation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/fairness-recsys-allocation/index.ja.md
+++ b/content/publications/fairness-recsys-allocation/index.ja.md
@@ -7,7 +7,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["fairness-recsys-allocation"]
-project_names: ["Fairness in Recommender Systems and Allocation"]
 topics: ["Fairness","Recommender Systems","Resource Allocation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/filtered-direct-preference-optimization-2024-2/index.ja.md
+++ b/content/publications/filtered-direct-preference-optimization-2024-2/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Workshop"
 paper_lang: "en"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/filtered-direct-preference-optimization-2024-2/index.md
+++ b/content/publications/filtered-direct-preference-optimization-2024-2/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Workshop"
 paper_lang: "en"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/filtered-direct-preference-optimization-2024-3/index.ja.md
+++ b/content/publications/filtered-direct-preference-optimization-2024-3/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/filtered-direct-preference-optimization-2024/index.ja.md
+++ b/content/publications/filtered-direct-preference-optimization-2024/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/filtered-direct-preference-optimization-2024/index.md
+++ b/content/publications/filtered-direct-preference-optimization-2024/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/follow-the-regularized-leader-2022/index.ja.md
+++ b/content/publications/follow-the-regularized-leader-2022/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/global-behavior-of-learning-dynamics-in-zero-sum-games-2025/index.ja.md
+++ b/content/publications/global-behavior-of-learning-dynamics-in-zero-sum-games-2025/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/global-behavior-of-learning-dynamics-in-zero-sum-games-2025/index.md
+++ b/content/publications/global-behavior-of-learning-dynamics-in-zero-sum-games-2025/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/language-model-alignment-2022/index.ja.md
+++ b/content/publications/language-model-alignment-2022/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/language-model-alignment-2023/index.ja.md
+++ b/content/publications/language-model-alignment-2023/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/language-model-alignment-2024/index.ja.md
+++ b/content/publications/language-model-alignment-2024/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/language-model-alignment-2025-2/index.ja.md
+++ b/content/publications/language-model-alignment-2025-2/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/language-model-alignment-2025/index.ja.md
+++ b/content/publications/language-model-alignment-2025/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/last-iterate-convergence-in-monotone-mean-field-games-2024/index.ja.md
+++ b/content/publications/last-iterate-convergence-in-monotone-mean-field-games-2024/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/last-iterate-convergence-in-monotone-mean-field-games-2025/index.ja.md
+++ b/content/publications/last-iterate-convergence-in-monotone-mean-field-games-2025/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/last-iterate-convergence-in-monotone-mean-field-games-2025/index.md
+++ b/content/publications/last-iterate-convergence-in-monotone-mean-field-games-2025/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/last-iterate-convergence-with-full-and-noisy-feedback-i-2023/index.ja.md
+++ b/content/publications/last-iterate-convergence-with-full-and-noisy-feedback-i-2023/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/last-iterate-convergence-with-full-and-noisy-feedback-i-2023/index.md
+++ b/content/publications/last-iterate-convergence-with-full-and-noisy-feedback-i-2023/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/last-iterate-convergence-with-full-and-noisy-informatio-2022/index.ja.md
+++ b/content/publications/last-iterate-convergence-with-full-and-noisy-informatio-2022/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-dynamics-equilibrium-games-2/index.ja.md
+++ b/content/publications/learning-dynamics-equilibrium-games-2/index.ja.md
@@ -7,7 +7,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-dynamics-equilibrium-games-2019/index.ja.md
+++ b/content/publications/learning-dynamics-equilibrium-games-2019/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-dynamics-equilibrium-games-2021-2/index.ja.md
+++ b/content/publications/learning-dynamics-equilibrium-games-2021-2/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-dynamics-equilibrium-games-2021/index.ja.md
+++ b/content/publications/learning-dynamics-equilibrium-games-2021/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-dynamics-equilibrium-games-2022/index.ja.md
+++ b/content/publications/learning-dynamics-equilibrium-games-2022/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-dynamics-equilibrium-games-2023/index.ja.md
+++ b/content/publications/learning-dynamics-equilibrium-games-2023/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-dynamics-equilibrium-games-2024/index.ja.md
+++ b/content/publications/learning-dynamics-equilibrium-games-2024/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-dynamics-equilibrium-games-2025-2/index.ja.md
+++ b/content/publications/learning-dynamics-equilibrium-games-2025-2/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-dynamics-equilibrium-games-2025-3/index.ja.md
+++ b/content/publications/learning-dynamics-equilibrium-games-2025-3/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-dynamics-equilibrium-games-2025-4/index.ja.md
+++ b/content/publications/learning-dynamics-equilibrium-games-2025-4/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-dynamics-equilibrium-games-2025-5/index.ja.md
+++ b/content/publications/learning-dynamics-equilibrium-games-2025-5/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-dynamics-equilibrium-games-2025/index.ja.md
+++ b/content/publications/learning-dynamics-equilibrium-games-2025/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-dynamics-equilibrium-games-3/index.ja.md
+++ b/content/publications/learning-dynamics-equilibrium-games-3/index.ja.md
@@ -7,7 +7,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-dynamics-equilibrium-games/index.ja.md
+++ b/content/publications/learning-dynamics-equilibrium-games/index.ja.md
@@ -7,7 +7,6 @@ status: "Accepted"
 type: "Journal"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-fair-division-from-bandit-feedback-2024/index.ja.md
+++ b/content/publications/learning-fair-division-from-bandit-feedback-2024/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["fairness-recsys-allocation"]
-project_names: ["Fairness in Recommender Systems and Allocation"]
 topics: ["Fairness","Recommender Systems","Resource Allocation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-fair-division-from-bandit-feedback-2024/index.md
+++ b/content/publications/learning-fair-division-from-bandit-feedback-2024/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["fairness-recsys-allocation"]
-project_names: ["Fairness in Recommender Systems and Allocation"]
 topics: ["Fairness","Recommender Systems","Resource Allocation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-from-delayed-feedback-in-games-via-extra-predi-2025/index.ja.md
+++ b/content/publications/learning-from-delayed-feedback-in-games-via-extra-predi-2025/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-from-delayed-feedback-in-games-via-extra-predi-2025/index.md
+++ b/content/publications/learning-from-delayed-feedback-in-games-via-extra-predi-2025/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-in-multi-memory-games-triggers-complex-dynamic-2023-2/index.ja.md
+++ b/content/publications/learning-in-multi-memory-games-triggers-complex-dynamic-2023-2/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-in-multi-memory-games-triggers-complex-dynamic-2023/index.ja.md
+++ b/content/publications/learning-in-multi-memory-games-triggers-complex-dynamic-2023/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/learning-in-multi-memory-games-triggers-complex-dynamic-2023/index.md
+++ b/content/publications/learning-in-multi-memory-games-triggers-complex-dynamic-2023/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/memory-asymmetry-creates-heteroclinic-orbits-to-nash-eq-2024/index.ja.md
+++ b/content/publications/memory-asymmetry-creates-heteroclinic-orbits-to-nash-eq-2024/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/memory-asymmetry-creates-heteroclinic-orbits-to-nash-eq-2024/index.md
+++ b/content/publications/memory-asymmetry-creates-heteroclinic-orbits-to-nash-eq-2024/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/model-based-minimum-bayes-risk-decoding-2024/index.ja.md
+++ b/content/publications/model-based-minimum-bayes-risk-decoding-2024/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/model-based-minimum-bayes-risk-decoding-2024/index.md
+++ b/content/publications/model-based-minimum-bayes-risk-decoding-2024/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/mutation-driven-follow-the-regularized-leader-for-last-2022/index.ja.md
+++ b/content/publications/mutation-driven-follow-the-regularized-leader-for-last-2022/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/mutation-driven-follow-the-regularized-leader-for-last-2022/index.md
+++ b/content/publications/mutation-driven-follow-the-regularized-leader-for-last-2022/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/nash-equilibrium-and-learning-dynamics-in-three-player-2025/index.ja.md
+++ b/content/publications/nash-equilibrium-and-learning-dynamics-in-three-player-2025/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/nash-equilibrium-and-learning-dynamics-in-three-player-2025/index.md
+++ b/content/publications/nash-equilibrium-and-learning-dynamics-in-three-player-2025/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/off-policy-exploitability-evaluation-in-two-player-zero-2021/index.ja.md
+++ b/content/publications/off-policy-exploitability-evaluation-in-two-player-zero-2021/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/off-policy-exploitability-evaluation-in-two-player-zero-2021/index.md
+++ b/content/publications/off-policy-exploitability-evaluation-in-two-player-zero-2021/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/online-learning-for-bidding-agent-in-first-price-auctio-2020/index.ja.md
+++ b/content/publications/online-learning-for-bidding-agent-in-first-price-auctio-2020/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Workshop"
 paper_lang: "en"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Bandits","Online Learning","Bayesian Optimization"]
 showDate: false
 showReadingTime: false

--- a/content/publications/online-learning-for-bidding-agent-in-first-price-auctio-2020/index.md
+++ b/content/publications/online-learning-for-bidding-agent-in-first-price-auctio-2020/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Workshop"
 paper_lang: "en"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Bandits","Online Learning","Bayesian Optimization"]
 showDate: false
 showReadingTime: false

--- a/content/publications/policy-gradient-algorithms-with-monte-carlo-tree-search-2024/index.ja.md
+++ b/content/publications/policy-gradient-algorithms-with-monte-carlo-tree-search-2024/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/policy-gradient-algorithms-with-monte-carlo-tree-search-2024/index.md
+++ b/content/publications/policy-gradient-algorithms-with-monte-carlo-tree-search-2024/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/policy-testing-in-markov-decision-processes-2025-2/index.ja.md
+++ b/content/publications/policy-testing-in-markov-decision-processes-2025-2/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/policy-testing-in-markov-decision-processes-2025/index.ja.md
+++ b/content/publications/policy-testing-in-markov-decision-processes-2025/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Workshop"
 paper_lang: "en"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/policy-testing-in-markov-decision-processes-2025/index.md
+++ b/content/publications/policy-testing-in-markov-decision-processes-2025/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Workshop"
 paper_lang: "en"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/policy-testing-in-markov-decision-processes-2026/index.ja.md
+++ b/content/publications/policy-testing-in-markov-decision-processes-2026/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/policy-testing-in-markov-decision-processes-2026/index.md
+++ b/content/publications/policy-testing-in-markov-decision-processes-2026/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/regularized-best-of-n-sampling-to-mitigate-reward-hacki-2024/index.ja.md
+++ b/content/publications/regularized-best-of-n-sampling-to-mitigate-reward-hacki-2024/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Workshop"
 paper_lang: "en"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/regularized-best-of-n-sampling-to-mitigate-reward-hacki-2024/index.md
+++ b/content/publications/regularized-best-of-n-sampling-to-mitigate-reward-hacki-2024/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Workshop"
 paper_lang: "en"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/regularized-best-of-n-sampling-with-minimum-bayes-risk-2025/index.ja.md
+++ b/content/publications/regularized-best-of-n-sampling-with-minimum-bayes-risk-2025/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/regularized-best-of-n-sampling-with-minimum-bayes-risk-2025/index.md
+++ b/content/publications/regularized-best-of-n-sampling-with-minimum-bayes-risk-2025/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/reinforcement-learning-sequential-decision-2/index.ja.md
+++ b/content/publications/reinforcement-learning-sequential-decision-2/index.ja.md
@@ -7,7 +7,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/reinforcement-learning-sequential-decision-2016-2/index.ja.md
+++ b/content/publications/reinforcement-learning-sequential-decision-2016-2/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/reinforcement-learning-sequential-decision-2016/index.ja.md
+++ b/content/publications/reinforcement-learning-sequential-decision-2016/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/reinforcement-learning-sequential-decision-2017/index.ja.md
+++ b/content/publications/reinforcement-learning-sequential-decision-2017/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/reinforcement-learning-sequential-decision-2020/index.ja.md
+++ b/content/publications/reinforcement-learning-sequential-decision-2020/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/reinforcement-learning-sequential-decision-2023/index.ja.md
+++ b/content/publications/reinforcement-learning-sequential-decision-2023/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/reinforcement-learning-sequential-decision-2024-2/index.ja.md
+++ b/content/publications/reinforcement-learning-sequential-decision-2024-2/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/reinforcement-learning-sequential-decision-2024/index.ja.md
+++ b/content/publications/reinforcement-learning-sequential-decision-2024/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/reinforcement-learning-sequential-decision-3/index.ja.md
+++ b/content/publications/reinforcement-learning-sequential-decision-3/index.ja.md
@@ -7,7 +7,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/reinforcement-learning-sequential-decision-4/index.ja.md
+++ b/content/publications/reinforcement-learning-sequential-decision-4/index.ja.md
@@ -7,7 +7,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/reinforcement-learning-sequential-decision/index.ja.md
+++ b/content/publications/reinforcement-learning-sequential-decision/index.ja.md
@@ -7,7 +7,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["Reinforcement Learning","Sequential Decision Making","Markov Games","Policy Evaluation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/return-aligned-decision-transformer/index.ja.md
+++ b/content/publications/return-aligned-decision-transformer/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Journal"
 paper_lang: "en"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/return-aligned-decision-transformer/index.md
+++ b/content/publications/return-aligned-decision-transformer/index.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Journal"
 paper_lang: "en"
 projects: ["reinforcement-learning-sequential-decision"]
-project_names: ["Reinforcement Learning and Sequential Decision Making"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/rlhf-2024/index.ja.md
+++ b/content/publications/rlhf-2024/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/scalable-and-provably-fair-exposure-control-for-large-s-2024/index.ja.md
+++ b/content/publications/scalable-and-provably-fair-exposure-control-for-large-s-2024/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["fairness-recsys-allocation"]
-project_names: ["Fairness in Recommender Systems and Allocation"]
 topics: ["Fairness","Recommender Systems","Resource Allocation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/scalable-and-provably-fair-exposure-control-for-large-s-2024/index.md
+++ b/content/publications/scalable-and-provably-fair-exposure-control-for-large-s-2024/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["fairness-recsys-allocation"]
-project_names: ["Fairness in Recommender Systems and Allocation"]
 topics: ["Fairness","Recommender Systems","Resource Allocation"]
 showDate: false
 showReadingTime: false

--- a/content/publications/synchronization-behind-learning-in-periodic-zero-sum-ga-2024/index.ja.md
+++ b/content/publications/synchronization-behind-learning-in-periodic-zero-sum-ga-2024/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/synchronization-behind-learning-in-periodic-zero-sum-ga-2025/index.ja.md
+++ b/content/publications/synchronization-behind-learning-in-periodic-zero-sum-ga-2025/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/synchronization-behind-learning-in-periodic-zero-sum-ga-2025/index.md
+++ b/content/publications/synchronization-behind-learning-in-periodic-zero-sum-ga-2025/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/the-power-of-perturbation-under-sampling-in-solving-ext/index.ja.md
+++ b/content/publications/the-power-of-perturbation-under-sampling-in-solving-ext/index.ja.md
@@ -8,7 +8,6 @@ status: "Preprint"
 type: "Preprint"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/the-power-of-perturbation-under-sampling-in-solving-ext/index.md
+++ b/content/publications/the-power-of-perturbation-under-sampling-in-solving-ext/index.md
@@ -8,7 +8,6 @@ status: "Preprint"
 type: "Preprint"
 paper_lang: "en"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/thresholded-lasso-bandit-2022-2/index.ja.md
+++ b/content/publications/thresholded-lasso-bandit-2022-2/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Bandits","Online Learning","Bayesian Optimization"]
 showDate: false
 showReadingTime: false

--- a/content/publications/thresholded-lasso-bandit-2022/index.ja.md
+++ b/content/publications/thresholded-lasso-bandit-2022/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Bandits","Online Learning","Bayesian Optimization"]
 showDate: false
 showReadingTime: false

--- a/content/publications/thresholded-lasso-bandit-2022/index.md
+++ b/content/publications/thresholded-lasso-bandit-2022/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Bandits","Online Learning","Bayesian Optimization"]
 showDate: false
 showReadingTime: false

--- a/content/publications/time-varyingness-in-auction-breaks-revenue-equivalence-2026/index.ja.md
+++ b/content/publications/time-varyingness-in-auction-breaks-revenue-equivalence-2026/index.ja.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/time-varyingness-in-auction-breaks-revenue-equivalence-2026/index.md
+++ b/content/publications/time-varyingness-in-auction-breaks-revenue-equivalence-2026/index.md
@@ -9,7 +9,6 @@ status: "Accepted"
 type: "Conference"
 paper_lang: "en"
 projects: ["bandits-online-learning"]
-project_names: ["Bandits and Online Learning"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/unified-convergence-guarantees-for-learning-with-genera-2025/index.ja.md
+++ b/content/publications/unified-convergence-guarantees-for-learning-with-genera-2025/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/content/publications/why-guided-dialog-policy-learning-performs-well-underst/index.ja.md
+++ b/content/publications/why-guided-dialog-policy-learning-performs-well-underst/index.ja.md
@@ -8,7 +8,6 @@ status: "Preprint"
 type: "Preprint"
 paper_lang: "en"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/why-guided-dialog-policy-learning-performs-well-underst/index.md
+++ b/content/publications/why-guided-dialog-policy-learning-performs-well-underst/index.md
@@ -8,7 +8,6 @@ status: "Preprint"
 type: "Preprint"
 paper_lang: "en"
 projects: ["language-model-alignment"]
-project_names: ["Language Model Alignment and Preference Optimization"]
 topics: ["LLM Alignment","Preference Optimization","Decoding"]
 showDate: false
 showReadingTime: false

--- a/content/publications/zero-variance-perturbation-utiity-for-extensive-form-ga-2023/index.ja.md
+++ b/content/publications/zero-variance-perturbation-utiity-for-extensive-form-ga-2023/index.ja.md
@@ -8,7 +8,6 @@ status: "Accepted"
 type: "Domestic"
 paper_lang: "ja"
 projects: ["learning-dynamics-equilibrium-games"]
-project_names: ["Learning Dynamics and Equilibrium Computation in Games"]
 topics: ["Learning in Games","Learning Dynamics","Equilibrium Computation","Last-Iterate Convergence","Game Theory"]
 showDate: false
 showReadingTime: false

--- a/layouts/partials/publication-card.html
+++ b/layouts/partials/publication-card.html
@@ -7,7 +7,12 @@
 {{- $authors := .Params.authors | default slice -}}
 {{- $topics := .Params.topics | default slice -}}
 {{- $projects := .Params.projects | default slice -}}
-{{- $projectNames := .Params.project_names | default slice -}}
+{{- $projectNames := slice -}}
+{{- range $projects -}}
+  {{- $nm := . -}}
+  {{- with site.GetPage (printf "/research/%s" .) -}}{{- $nm = .Title -}}{{- end -}}
+  {{- $projectNames = $projectNames | append $nm -}}
+{{- end -}}
 {{- $links := .Params.links | default slice -}}
 {{- $primary := "" -}}
 {{- if $links -}}{{- $primary = (index $links 0).url -}}{{- end -}}
@@ -29,7 +34,7 @@
   </h3>
   {{ with $authors }}<p class="pub-authors">{{ delimit . ", " }}</p>{{ end }}
   {{ if $projects }}
-    <a class="pub-project" href="/research/{{ index $projects 0 }}/">{{ if $projectNames }}{{ index $projectNames 0 }}{{ else }}{{ index $projects 0 }}{{ end }}</a>
+    <a class="pub-project" href="/research/{{ index $projects 0 }}/">{{ index $projectNames 0 }}</a>
   {{ end }}
   {{ with $links }}<div class="pub-links">{{ range . }}<a class="pub-link" href="{{ .url }}" target="_blank" rel="noopener">{{ .name }}</a>{{ end }}</div>{{ end }}
 </article>

--- a/layouts/publications/list.html
+++ b/layouts/publications/list.html
@@ -18,7 +18,7 @@
       {{ with .Params.type }}{{ $types = $types | append . }}{{ end }}
       {{ with .Params.year }}{{ $years = $years | append . }}{{ end }}
       {{ with .Params.venue_short }}{{ $venues = $venues | append . }}{{ end }}
-      {{ if .Params.projects }}{{ $themes = merge $themes (dict (index .Params.projects 0) (cond (gt (len (.Params.project_names | default slice)) 0) (index .Params.project_names 0) (index .Params.projects 0))) }}{{ end }}
+      {{ if .Params.projects }}{{ $slug := index .Params.projects 0 }}{{ $nm := $slug }}{{ with site.GetPage (printf "/research/%s" $slug) }}{{ $nm = .Title }}{{ end }}{{ $themes = merge $themes (dict $slug $nm) }}{{ end }}
     {{ end }}
     {{ $statuses = $statuses | uniq }}
     {{ $years = collections.Reverse ($years | uniq | sort) }}


### PR DESCRIPTION
## Summary

Publications の `project_names` は不要、という指摘（#4）への対応。

各 publication は研究テーマ紐付け用の `projects`（slug）と、表示名 `project_names`（テーマの Title）の両方を持っていたが、表示名は slug から研究テーマページの Title を引けば導出できる冗長フィールドだった。`site.GetPage` でテーマ Title を引くようレイアウトを変更し、全 publication から `project_names` を削除。

副次効果として、表示名が固定英語文字列ではなく研究テーマページの言語に追従するようになる（現状テーマ Title は英語なので表示は不変）。

## Changes

- `layouts/partials/publication-card.html`: `projects` の slug から `site.GetPage` でテーマ Title を導出（表示名・検索文字列の両方）。slug フォールバック付き
- `layouts/publications/list.html`: テーマフィルタの表示名も同様に slug から導出
- `content/publications/**/index*.md`（133ファイル）: `project_names` 行を削除

## Test plan

- [x] `hugo server` で EN/JA の `/publications/` のテーマリンク・テーマフィルタ名が従来と一致することを確認
- [x] 研究テーマ詳細ページの関連論文カードのテーマリンクも従来どおり表示
- [x] 検索文字列（`data-search`）にテーマ名が引き続き含まれることを確認
- [x] `hugo` フルビルド成功（エラーなし）

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)