### PR TITLE
fix: 研究テーマの関連論文を英語論文のみに絞る

### DIFF
--- a/content/publications/_content.gotmpl
+++ b/content/publications/_content.gotmpl
@@ -22,6 +22,7 @@
           "year"            $year
           "date"            $date
           "type"            (or $v.type "")
+          "lang"            (or $v.lang "en")
           "projects"        (or $proj.projects slice)
           "links"           (or $v.links slice)
           "abstract"        (or $v.abstract "")

--- a/content/publications/_content.ja.gotmpl
+++ b/content/publications/_content.ja.gotmpl
@@ -22,6 +22,7 @@
           "year"            $year
           "date"            $date
           "type"            (or $v.type "")
+          "lang"            (or $v.lang "en")
           "projects"        (or $proj.projects slice)
           "links"           (or $v.links slice)
           "abstract"        (or $v.abstract "")

--- a/layouts/research/list.html
+++ b/layouts/research/list.html
@@ -15,7 +15,7 @@
     <section class="research-grid">
       {{ range $i, $p := .Pages.ByParam "order" }}
         {{ $id := path.Base $p.File.Dir }}
-        {{ $count := len (where (where site.RegularPages "Section" "publications") "Params.projects" "intersect" (slice $id)) }}
+        {{ $count := len (where (where (where site.RegularPages "Section" "publications") "Params.projects" "intersect" (slice $id)) "Params.lang" "en") }}
         {{ $img := ($p.Resources.ByType "image").GetMatch "*featured*" }}
         {{ $hue := mod (mul $i 53) 360 }}
         <div class="research-item">

--- a/layouts/research/single.html
+++ b/layouts/research/single.html
@@ -10,7 +10,8 @@
   </article>
 
   {{ $id := path.Base .File.Dir }}
-  {{ $related := where (where .Site.RegularPages "Section" "publications") "Params.projects" "intersect" (slice $id) }}
+  {{/* Related publications exclude JA-only venues (domestic talks): show English papers only. */}}
+  {{ $related := where (where (where .Site.RegularPages "Section" "publications") "Params.projects" "intersect" (slice $id)) "Params.lang" "en" }}
   {{ with $related }}
     <section class="mt-12">
       <h2 class="text-2xl font-bold text-neutral-800 dark:text-neutral-200 mb-6">{{ i18n "x.related_publications" }}</h2>


### PR DESCRIPTION
## 概要

研究テーマページの「関連論文」一覧と、テーマカードに表示される関連論文件数から、日本語のみの発表（国内会議など `lang: ja` の venue）を除外する。英語論文だけを表示するようにした。

issue #11 の対応。日本語サイトではテーマページに国内発表が混ざっていたが、これを英語論文のみに統一する。

## 変更点

- `content/publications/_content.gotmpl` / `_content.ja.gotmpl`: 生成する各 publication ページの front-matter params に `lang`（venue の言語）を追加。
- `layouts/research/single.html`: 関連論文の絞り込みに `Params.lang == "en"` を追加し、英語論文のみ表示。
- `layouts/research/list.html`: テーマカードの「関連論文 N件」カウントも同じく英語論文のみで集計し、テーマページの表示件数と一致させる。

## 影響範囲

- 英語サイト: もともと en の venue のみ生成されるため表示は不変。
- 日本語サイト: テーマページの関連論文・件数から `lang: ja` の国内発表が除外される。
- 論文一覧ページ（`publications/`）の「国内発表」カテゴリは従来どおり維持（このPRの対象外）。

## テスト

- `hugo` でビルドが通ること（一時ディレクトリへ出力して確認）。
- 日本語サイトのテーマページで関連論文が英語のみになり、カードの件数と一致することを確認。

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)